### PR TITLE
"Fixed" greedily matching {_missing} routes

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -62,10 +62,13 @@ class RouteCollection implements Countable, IteratorAggregate {
 	{
 		foreach ($route->methods() as $method)
 		{
-			$this->routes[$method][] = $route;
-		}
+			array_forget($this->routes[$method], $route->domain().$route->getUri());
 
-		$this->allRoutes[] = $route;
+			$this->routes[$method][$route->domain().$route->getUri()] = $route;
+		}
+		array_forget($this->allRoutes, $method.$route->domain().$route->getUri());
+		
+		$this->allRoutes[$method.$route->domain().$route->getUri()] = $route;
 	}
 
 	/**


### PR DESCRIPTION
Well this is an awfully hacky solution... or at least the way it is structured is. A more logical solution would be to use array_last instead of array_first when matching routes, but that has been tried and it had some problems.
#2850
